### PR TITLE
Hide the Callback UI elements

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -389,6 +389,7 @@ a.callbacks_nav.callbacks1_nav.prev {
 }
 
 .callbacks_tabs{
+  display:none;
 	list-style: none;
 	position: absolute;
 	top: 141%;


### PR DESCRIPTION
Just hidden the Callback UI elements for now, so that we can work on them in the future. Transition still works.
